### PR TITLE
Ensure to enable the latest TLS/SSL policy for the load balancer

### DIFF
--- a/Infraestructura/Web/_cognitive.tf
+++ b/Infraestructura/Web/_cognitive.tf
@@ -13,6 +13,7 @@ resource "azurerm_storage_account" "bbvatf-form-store" {
   resource_group_name      = azurerm_resource_group.bbvatf-rg.name
   account_tier             = "Standard"
   account_replication_type = "LRS"
+  min_tls_version = "TLS1_2"
 }
 
 resource "azurerm_storage_container" "bbvatf-form-store-co" {


### PR DESCRIPTION
This pull request improves our infrastructure by fixing a security issue found by [Shisho Cloud](https://shisho.dev).

## Description from Shisho Cloud

It is better to enable the latest TLS/SSL policy for the load balancer. Three versions of the TLS protocol, 1.0, 1.1, and 1.2 are available at the moment. TLS 1.2 should be selected if you do not have special reasons.

